### PR TITLE
docs/cli: remove `search` command

### DIFF
--- a/D-docs/01-cli/00-index.md
+++ b/D-docs/01-cli/00-index.md
@@ -32,7 +32,6 @@ keybase prove dns you.com    # prove via a DNS entry
 #### Looking up other people & following
 
 ```bash
-keybase search max                 # find users like "max"
 keybase id max                     # look "max" up, verify identity
 keybase id maxtaco@twitter         # look twitter maxtaco up
 keybase follow max                 # track max's identity publicly


### PR DESCRIPTION
`search` doesn't appear to be a valid command, assuming it was removed at some point

    ↯ keybase search asdf
    No help topic for 'search'