### PR TITLE
docs/teams/seitan: EdDSA keypair is generated from seed, not from private key

### DIFF
--- a/D-docs/03-teams/10-seitan.md
+++ b/D-docs/03-teams/10-seitan.md
@@ -98,10 +98,8 @@ MAC key. Then the first 15 bytes are used for the "invitation ID".
 
 Using the `siKey`, we
 [generate](https://github.com/keybase/client/blob/98327b58939a5b769fb2025743a31fcd08c7265b/go/teams/seitan_v2.go#L103-L134)
-an EdDSA keypair as follows `privKey = HMAC(sikey, {"stage" : "eddsa",
-"version" : 2})[0:32]` and `pubKey = NewEdDSAPublic(privkey)` which we use
-later to produce a signature to verify our invitation id.
-
+an EdDSA keypair as follows `seed = HMAC(sikey, {"stage" : "eddsa", "version" : 2})[0:32]` 
+and `keyPair = NewEdDSA(seed)` which we use later to produce a signature to verify our invitation id.
 
 ### Step 2: Encryption and Signing of the pubKey
 


### PR DESCRIPTION
The [docs state](https://keybase.io/docs/teams/seitan_v2#step-1d-generate-eddsa-keypair) that the EdDSA keypair is created by treating the hashed payload as a *secret key*, used to generate a *public key*. 

This wouldn't work, and the `generateKeyPair` function in fact treats the hashed payload as a *seed*, used to generate a new *keypair*.

https://github.com/keybase/client/blob/e95e0d09602849233c20abac6c1df9e06824d4a6/go/teams/seitan_v2.go#L87-L118
