### PR TITLE
Update 00-index.md

### DIFF
--- a/D-docs/01-cli/00-index.md
+++ b/D-docs/01-cli/00-index.md
@@ -1,6 +1,6 @@
 # Command Line
 
-This page is just a sampler. [Download](/download) the Keybase app and use the built-in help:
+This page is just a sampler. [Download](https://keybase.io/download) the Keybase app and use the built-in help:
 
 ```bash
 keybase help        # general


### PR DESCRIPTION
Change download link to an absolute link, instead of relative link, since https://book.keybase.io/download leads to a 404, whereas https://keybase.io/download is correct