### PR TITLE
change old /server_security links to /server

### DIFF
--- a/D-docs/08-crypto/00-index.md
+++ b/D-docs/08-crypto/00-index.md
@@ -6,9 +6,9 @@ Keybase system.
 
 ## Core Security
 
-[This document](/docs/server_security) describes our high-level approach to system security: namely, that Keybase clients take hints and raw data from our server, but mistrust it, and check all of its work.
+[This document](/docs/server) describes our high-level approach to system security: namely, that Keybase clients take hints and raw data from our server, but mistrust it, and check all of its work.
 
-We posted a [follow-on public document](/docs/server_security/merkle_root_in_bitcoin_blockchain) describing how we use the bitcoin blockchain to enhance security guarantees.
+We posted a [follow-on public document](/docs/server/merkle_root_in_bitcoin_blockchain) describing how we use the bitcoin blockchain to enhance security guarantees.
 
 As we launched per-device secret keys, we posted another [document](/docs/sigchain) describing the specifics of user signature chains, and how users go about delegating authority to new keys and revoking old keys.
 

--- a/D-docs/08-crypto/03-kbfs.md
+++ b/D-docs/08-crypto/03-kbfs.md
@@ -548,7 +548,7 @@ body .kbfs-crypto-spec {
   <h3>The Keybase Core Merkle Tree</h3>
 
   <p>
-    As described in <a href="../server_security">our
+    As described in <a href="../server">our
     Server Security</a> document, users sign statements about their keys,
     their identities and the identities of others. They commit these
     signatures to monotonically growing signature chains, which are collected


### PR DESCRIPTION
I only changed links in "08-crypto/" but there are more instances of
defunct "/server_security" that need fixing.