### PR TITLE
Fix broken links

### DIFF
--- a/D-docs/04-chat/00-index.md
+++ b/D-docs/04-chat/00-index.md
@@ -2,11 +2,11 @@
 
 Here is the technical documentation for chat:
 
-- [Crypto](crypto) describes the use of cryptography in chat.
-- [Exploding Messages](ephemeral) explains the technical details of exploding
+- [Crypto](/docs/chat/crypto) describes the use of cryptography in chat.
+- [Exploding Messages](/docs/chat/ephemeral) explains the technical details of exploding
   messages.
-- [Link Previews](linkpreviews) discusses how privacy is respected when posting
+- [Link Previews](/docs/chat/linkpreviews) discusses how privacy is respected when posting
   URLs that can be previewed inline.
-- [Location Sharing](location) discusses how the location sharing feature is implemented.
-- [Coin Flip](coinflip) describes the /flip coin flipping protocol.
-- [Phone Numbers and Emails](chat/phones-and-emails) describes how users can start conversations with phone numbers or emails.
+- [Location Sharing](/docs/chat/location) discusses how the location sharing feature is implemented.
+- [Coin Flip](/docs/chat/coin-flip) describes the /flip coin flipping protocol.
+- [Phone Numbers and Emails](/docs/chat/phones-and-emails) describes how users can start conversations with phone numbers or emails.

--- a/D-docs/10-linux/00-index.md
+++ b/D-docs/10-linux/00-index.md
@@ -548,7 +548,7 @@ Our code signing fingerprint is in the same directory at
 website](https://keybase.io/docs/server_security/our_code_signing_key).
 
 You can also extract the binaries we build ourselves from the `.deb` files in
-[our release directory](prerelease.keybase.io/linux_binaries/deb/index.html)
+[our release directory](https://prerelease.keybase.io/linux_binaries/deb/index.html)
 instead of building from source. You may choose to package Keybase, KBFS,
 and the GUI all together or in separate packages, but make sure the
 dependencies are specified.


### PR DESCRIPTION
 
* docs/chat: use absolute URLs in links: \
relative URLs don't work if the URL where the link is on doesn't end in a "/", i.e. it would only work on https://book.keybase.io/docs/chat/ but not on https://book.keybase.io/docs/chat (which is actually used)
    
* docs/chat: fixed typo in coin-flip URL (missing "-")

* docs/linux: fix broken link to release directory (missing scheme)