### PR TITLE
Add note that Keybase.pub was discontinued in 20230301

### DIFF
--- a/D-docs/14-sites/00-index.md
+++ b/D-docs/14-sites/00-index.md
@@ -1,10 +1,13 @@
+**Note**: As of March 1, 2023, [the Keybase.pub service was discontinued](https://www.reddit.com/r/Keybase/comments/10xeqbw/keybasepub_shutting_down_on_short_notice/). This page is just archived
+for historic purposes.
+* * *
   ## Keybase.pub
 
   [Keybase.pub](https://keybase.pub) serves anything it can find in `/keybase/public`. Poetry. Cat pics. Midi files. Hot, hot recipes.
 
   For example, here we see `/keybase/public/chris/photos/` served at https://keybase.pub/chris/photos :
 
-  <img src="/images/getting-started/kpub-screenshot.jpg" class="img img-responsive">
+  ~~<img src="/images/getting-started/kpub-screenshot.jpg" class="img img-responsive">~~
 
   #### Raw vs. wrapped
 


### PR DESCRIPTION
The link provided goes to Reddit (where I first read the notice), but I vaguely recall seeing the discontinuation notice on one of the public Keybase websites. I'm afraid I couldn't find it, but here it is, verbatim:

> We regret to inform you that the Keybase.pub web hosting service will be shutting down on March 1, 2023. Although the service was a great showcase for the kinds of cool things that could be built with Keybase, the usage of this product never took off. The continued cost of maintaining the site has led us to make the difficult decision to shut it down. If you are hosting any content on Keybase.pub, we strongly recommend moving that content to a new hosting provider as soon as possible.
> 
> No Keybase Filesystem (KBFS) data will be removed from any user public folders. All data will remain safe and viewable by others running Keybase. Other features of Keybase including Chat, KBFS, Teams, Git, Wallet and others will continue to run normally as well.
> 
> -Keybase