### PR TITLE
fix: correct grammar, spelling, and formatting errors

### DIFF
--- a/02-chat/00-index.md
+++ b/02-chat/00-index.md
@@ -46,7 +46,7 @@ If someone you don’t follow and haven’t chatted with before contacts you on 
 ### Blocking
 When you block someone, they won’t be able to chat with you or add you to a team. You can also remove them from your public list of followers. You won’t see them, and their account will not be publicly associated with yours.
 
-But they can still follow you. They may also know that you blocked them because they won’t be able to chat with you or add you to a team.
+But they can still follow you. They may also know that you've blocked them because they won't be able to chat with you or add you to a team.
 
 ### Reporting
 When you report someone, we review their account as quickly as humanly possible. We will remove people that have violated our [terms](https://keybase.io/docs/terms). Please provide additional information so we can remove spammers, abusers, and harassers even faster.

--- a/06-wallet/00-index.md
+++ b/06-wallet/00-index.md
@@ -13,7 +13,7 @@ You can learn more on the [blog](https://keybase.io/blog/keybase-stellar-launch)
 ## Sending Lumens
 You can send, receive, and buy Lumens from Keybase Wallet or Chat. 
 
-You can send Lumens to other people on Keybase, to Stellar addresses, or to your other Stellar accounts. You can request  funds from people on and outside of Keybase. And, you can buy Lumens through external partners that are not affiliated with Keybase.
+You can send Lumens to other people on Keybase, to Stellar addresses, or to your other Stellar accounts. You can request funds from people on and outside of Keybase. And, you can buy Lumens through external partners that are not affiliated with Keybase.
 
 ### Chat
 One of the quickest ways to send Lumens to others on Keybase is through Chat. Just include this format in your message `+123XLM@username`. To do so:
@@ -51,11 +51,11 @@ Once you have trustlines set up, you can send other currencies to other people o
 
 If your recipient has a trustline for other currencies, Keybase will let you know that this person accepts funds other than Lumens.
 
-You can also exchange Lumens into other currencies outside of  Keybase. To do so, you’ll need your Stellar address and secret key. 
+You can also exchange Lumens into other currencies outside of Keybase. To do so, you’ll need your Stellar address and secret key. 
 
 ## About Stellar 
- We love Stellar for a couple reasons. One is that [Keybase is funded by the Stellar Development Foundation](https://keybase.io/blog/keybase-stellar). And two is that we think Stellar is actually a great decentralized, open-source, multi-currency network. Unlike most others, Stellar supports global transactions and automatically converts Lumens into whatever currency you prefer.
+We love Stellar for a couple reasons. One is that [Keybase is funded by the Stellar Development Foundation](https://keybase.io/blog/keybase-stellar). And two is that we think Stellar is actually a great decentralized, open-source, multi-currency network. Unlike most others, Stellar supports global transactions and automatically converts Lumens into whatever currency you prefer.
 
- Plus, transactions cost a fraction of a cent, are very fast, and don’t consume massive amounts of energy. (For a little context, Bitcoin uses at least 22 terawatt-hours (TWh) of energy annually—almost the same as the entire country of Ireland. Compare this to Google, which used 5.7 TWh globally, in 2015.)
+Plus, transactions cost a fraction of a cent, are very fast, and don't consume massive amounts of energy. (For a little context, Bitcoin uses at least 22 terawatt-hours (TWh) of energy annually—almost the same as the entire country of Ireland. Compare this to Google, which used 5.7 TWh globally, in 2015.)
 
- Learn more about Stellar on their [site](https://www.stellar.org/learn/intro-to-stellar).
+Learn more about Stellar on their [site](https://www.stellar.org/learn/intro-to-stellar).

--- a/C-guides/04-pgp-in-javascript.md
+++ b/C-guides/04-pgp-in-javascript.md
@@ -284,7 +284,7 @@ kbpgp.KeyManager.generate(opts, some_callback_function);
 
 If you pass an ASP object, as described above, you can use it to cancel your process.
 
-```javaascript
+```javascript
 kbpgp.KeyManager.generate(opts, some_callback_function);
 
 // oh, heck, let's give up if it takes more than a second
@@ -372,7 +372,7 @@ kbpgp.box (params, function(err, result_string, result_buffer) {
 
 kbpgp can take *Node.js Buffers* as input, instead of strings. The following reads a .png file and writes a new encrypted copy of it. For more info, check out the kbpgp [buffers](#files-and-buffers) documentation.
 
-```javaascript
+```javascript
 var kbpgp  = require('kbpgp');
 var fs     = require('fs');
 var buffer = fs.readFileSync('dirty_deeds.png');

--- a/D-docs/12-lockdown/00-index.md
+++ b/D-docs/12-lockdown/00-index.md
@@ -1,7 +1,7 @@
 
 # Lockdown Mode
 
-Keybase users can opt! into _lockdown mode_ if they want extra protection for
+Keybase users can opt into _lockdown mode_ if they want extra protection for
 their account. Doing so will disable all Web site features that mutate or
 expose sensitive cloud-hosted data. Once in lockdown mode, all
 security-sensitive features must be performed on a valid Keybase device, with an active


### PR DESCRIPTION
- Fixed apostrophe in "you've blocked them" in chat documentation
- Removed double spaces in wallet documentation
- Corrected "javaascript" typos to "javascript" in PGP guide
- Removed errant exclamation mark from "opt into" in lockdown docs
- Fixed spacing and indentation issues in wallet section

🤖 Generated with [Claude Code](https://claude.ai/code)

Here's what Claude had to say when it ran:
Review Complete

  I've reviewed the entire book content and fixed the following issues:

  Fixed:
  1. 02-chat/00-index.md: Added missing apostrophe in "you've blocked them"
  2. 06-wallet/00-index.md: Removed double space in "request funds"
  3. 06-wallet/00-index.md: Removed double space before "Keybase"
  4. 06-wallet/00-index.md: Fixed indentation and spacing issues
  5. C-guides/04-pgp-in-javascript.md: Fixed typo "javaascript" → "javascript" (2 instances)
  6. D-docs/12-lockdown/00-index.md: Removed errant exclamation mark in "opt!"

  The book is generally well-written with only minor issues found. Most files had no errors at all.